### PR TITLE
Fix various frontend linting and TypeScript errors

### DIFF
--- a/frontend/src/components/ContainerRow.test.tsx
+++ b/frontend/src/components/ContainerRow.test.tsx
@@ -81,6 +81,7 @@ describe('ContainerRow Log Streaming', () => {
         onAction={jest.fn()}
         isExpanded={false}
         onToggleExpand={jest.fn()}
+        actionInProgress={null}
       />
     );
 
@@ -102,6 +103,7 @@ describe('ContainerRow Log Streaming', () => {
         onAction={jest.fn()}
         isExpanded={false}
         onToggleExpand={jest.fn()}
+        actionInProgress={null}
       />
     );
 
@@ -142,6 +144,7 @@ describe('ContainerRow Log Streaming', () => {
         onAction={jest.fn()}
         isExpanded={false}
         onToggleExpand={jest.fn()}
+        actionInProgress={null}
       />
     );
 
@@ -180,6 +183,7 @@ describe('ContainerRow Log Streaming', () => {
         onAction={jest.fn()}
         isExpanded={false}
         onToggleExpand={jest.fn()}
+        actionInProgress={null}
       />
     );
 
@@ -247,6 +251,7 @@ describe('ContainerRow Log Streaming', () => {
         onAction={jest.fn()}
         isExpanded={false}
         onToggleExpand={jest.fn()}
+        actionInProgress={null}
       />
     );
 
@@ -280,6 +285,7 @@ describe('ContainerRow Log Streaming', () => {
         onAction={jest.fn()}
         isExpanded={false}
         onToggleExpand={jest.fn()}
+        actionInProgress={null}
       />
     );
 

--- a/frontend/src/components/ContainerRow.tsx
+++ b/frontend/src/components/ContainerRow.tsx
@@ -10,6 +10,7 @@ import { config } from '../config';
 import { useWebSocket } from '../hooks/useWebSocket';
 import { useTheme } from '../context/ThemeContext';
 import { useContainerContext } from '../context/ContainerContext'; // Added
+import Tooltip from './shared/Tooltip'; // Added import
 import LogContainer from './LogContainer';
 import { CopyableText } from './CopyableText';
 
@@ -177,8 +178,6 @@ const PortDisplay: React.FC<{ portsString: string }> = ({ portsString }) => {
     );
 };
 
-import Tooltip from './shared/Tooltip'; // Added import
-
 export const ContainerRow: React.FC<ContainerRowProps> = ({
     container,
     isExpanded,
@@ -258,7 +257,7 @@ export const ContainerRow: React.FC<ContainerRowProps> = ({
             setIsLoadingLogs(false);
 
             // Try to restart the stream if it fails
-            if (isLogVisibleRef.current && streamActiveRef.current) { // Renamed
+            if (isLogVisibleRef.current && actualStreamIsRunning.current) { // Renamed
                 logger.info('Attempting to restart log stream after error', { containerId: container.id });
                 setTimeout(() => {
                     if (isLogVisibleRef.current) { // Renamed

--- a/frontend/src/context/ContainerContext.tsx
+++ b/frontend/src/context/ContainerContext.tsx
@@ -36,7 +36,7 @@ const initialState: ContainerState = {
     areAllLogsOpen: getInitialAllLogsOpen(), // Initialize from localStorage
 };
 
-const ContainerContext = createContext<{
+export const ContainerContext = createContext<{
     state: ContainerState;
     dispatch: React.Dispatch<ContainerAction>;
 }>({

--- a/frontend/src/context/ThemeContext.tsx
+++ b/frontend/src/context/ThemeContext.tsx
@@ -8,7 +8,7 @@ interface ThemeContextType {
     toggleTheme: () => void;
 }
 
-const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
+export const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
 
 export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
     // Check for saved theme or system preference


### PR DESCRIPTION
This commit addresses several issues identified in the frontend code:

1.  **ESLint Import Order:**
    - Moved `import Tooltip from './shared/Tooltip';` in `frontend/src/components/ContainerRow.tsx` to the top of the file to comply with import order rules.

2.  **TypeScript Context Exports:**
    - Exported `ContainerContext` from `frontend/src/context/ContainerContext.tsx`.
    - Exported `ThemeContext` from `frontend/src/context/ThemeContext.tsx`. This allows these contexts to be correctly imported in test files and other components.

3.  **TypeScript Prop Errors in Tests:**
    - Added the missing `actionInProgress` prop (set to `null`) to all instances of `<ContainerRow />` in `frontend/src/components/ContainerRow.test.tsx`. This aligns the test usage with the component's expected props.

4.  **TypeScript Variable Name Correction:**
    - In `frontend/src/components/ContainerRow.tsx`, within the `onError` callback of the `useWebSocket` hook, corrected the usage of `streamActiveRef.current` to `actualStreamIsRunning.current`. This ensures the logic for restarting a failed log stream correctly checks if the stream was previously active.